### PR TITLE
Add Legends of Future Past to Codebases

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ _Active and retired MUD codebases._
 - [FluffOS](https://github.com/fluffos/fluffos) - actively maintained LPMUD driver, based on the last release of MudOS.
 - [HellCore](https://github.com/necanthrope/HellCore) - HellCore fork of LambdaMOO.
 - [Kalevala](https://github.com/oestrich/kalevala) - World building toolkit for text based games, written in Elixir.
+- [Legends of Future Past](https://github.com/jonradoff/lofp) - 1992 commercial MUD resurrected from original script files using AI. Go backend, React frontend, WebSocket multiplayer. MIT license. [Play free](https://lofp.metavert.io).
 - [ldmud](https://github.com/ldmud/ldmud) - LDMud game driver for LPMuds.
 - [Ranvier](https://github.com/shawncplus/ranviermud) - Node.js-based MUD engine.
 - [RockMUD](https://github.com/MoreOutput/RockMUD) - Node.js-based WebSockets-capable MUD server.


### PR DESCRIPTION
[Legends of Future Past](https://github.com/jonradoff/lofp) was a commercial MUD that ran from 1992–1999 on CompuServe and the early internet. It won Computer Gaming World's 1993 Special Award for Artistic Excellence.

The original engine source code was lost over the years, but the game was reconstructed in 2026 from its original script files, GM documentation, and a 1996 gameplay session capture. The game content (2,000+ rooms, items, monsters, spells) is authentic — the same data players experienced in the 1990s, now running on a new open-source engine.

- **Tech**: Go + React + TypeScript + MongoDB + WebSocket
- **License**: MIT
- **Play now**: https://lofp.metavert.io
- **Wikipedia**: https://en.wikipedia.org/wiki/Legends_of_Future_Past